### PR TITLE
Fix minimum Puppet version requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
We use Puppet 6.x functions, so Puppet 5 is not supported.