### PR TITLE
Accept Undef passphrase for wifi::wpa_passphrase()

### DIFF
--- a/lib/puppet/functions/wifi/wpa_passphrase.rb
+++ b/lib/puppet/functions/wifi/wpa_passphrase.rb
@@ -11,7 +11,17 @@ Puppet::Functions.create_function(:'wifi::wpa_passphrase') do
     return_type 'String'
   end
 
+  dispatch :undef_wpa_passphrase do
+    param 'String', :ssid
+    param 'Undef', :passphrase
+    return_type 'Undef'
+  end
+
   def wpa_passphrase(ssid, passphrase)
     OpenSSL::PKCS5.pbkdf2_hmac_sha1(passphrase, ssid, 4096, 32).unpack1('H*')
+  end
+
+  def undef_wpa_passphrase(_ssid, _passphrase)
+    :undef
   end
 end

--- a/manifests/infrastructure.pp
+++ b/manifests/infrastructure.pp
@@ -15,9 +15,7 @@ define wifi::infrastructure (
 ) {
   include wifi
 
-  if $psk {
-    $real_psk = wifi::wpa_passphrase($ssid, $psk)
-  }
+  $real_psk = wifi::wpa_passphrase($ssid, $psk)
 
   case $facts.get('os.family') {
     'debian': {

--- a/spec/functions/wpa_passphrase_spec.rb
+++ b/spec/functions/wpa_passphrase_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'wifi::wpa_passphrase' do
+  it { is_expected.to run.with_params('Rocketjump GGGGG', '4 words all uppercase').and_return('992ae6a85385d87ffc9abed0da50f584eb13ba9ff9abf2c7eeedf53ef737aefd') }
+  it { is_expected.to run.with_params('Rocketjump Five Gee', 'four words all uppercase').and_return('fab9446327e36ff59d0b034a07f70408b320139c3e899144590ba10d1f506ce4') }
+  it { is_expected.to run.with_params('Rocketjump 5 and then the letter G', 'FOUR WORDS').and_return('12c59c191e1e7e26ab69e395ec8ed99c37abd57834193d963eb6840a0ece9414') }
+  it { is_expected.to run.with_params('Rocketjump 5, Gee!', '4 WORDS ALL UPPERCASE').and_return('83ebb725383a9e42097b585df09ac46e19e284196a99320616e047788abfe765') }
+  it { is_expected.to run.with_params('Rocketjump Eff Aiye Vee Ee Gee', 'FOURWORDS').and_return('978ed9c95f045ded9fa0e0cbfc5bc2794ccfba0cf8d2c037e3937d0412148614') }
+  it { is_expected.to run.with_params('Rocket, Jump 5, G', 'fourwordsalluppercase').and_return('ecfe115f5168d10c34eccff3e314145aedf429902ae3617d43769ec7764bdbff') }
+  it { is_expected.to run.with_params('The One That Says 5G', '4wordsalluppercase').and_return('9f54e9b2859c1c251ca9e0942aa837ddff12fd4dee065d69800e6c2534fc9f7b') }
+  it { is_expected.to run.with_params('Public Wi-Fi', :undef).and_return(:undef) }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+require 'rspec-puppet-facts'
+include RspecPuppetFacts # rubocop:disable Style/MixinUsage
+
+RSpec.configure do |c|
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
Return Undef when passphrase is undef.
This fix a warning in PuppetServer log when no pre-shared key is
provided.