### PR TITLE
Remove explicit data_provider from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,6 @@
   "summary": "Configures WiFi accesspoints",
   "project_page": "https://github.com/opus-codium/puppet-wifi",
   "issues_url": "https://github.com/opus-codium/puppet-wifi/issues",
-  "data_provider": "hiera",
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
The provider is inferred by the presence if the hiera.yaml file, and
data_provider has been deprecated with Puppet 5.

This fix a warning in the PuppetServer log.