### PR TITLE
Add support for hashed PSK

### DIFF
--- a/lib/puppet/functions/wifi/wpa_passphrase.rb
+++ b/lib/puppet/functions/wifi/wpa_passphrase.rb
@@ -7,7 +7,7 @@ Puppet::Functions.create_function(:'wifi::wpa_passphrase') do
   # @return [String] The hashed passphrase
   dispatch :wpa_passphrase do
     param 'String', :ssid
-    param 'String', :passphrase
+    param 'String[8,63]', :passphrase
     return_type 'String'
   end
 

--- a/manifests/infrastructure.pp
+++ b/manifests/infrastructure.pp
@@ -10,14 +10,18 @@ define wifi::infrastructure (
   Enum['present', 'absent'] $ensure   = 'present',
   Array[String]             $dns      = [],
   Optional[String]          $mac      = undef,
-  Optional[String[8,63]]    $psk      = undef,
+  Optional[String[8,64]]    $psk      = undef,
   Optional[String]          $ssid     = $name,
   Optional[String]          $uuid     = undef,
   Optional[Integer]         $priority = undef,
 ) {
   include wifi
 
-  $real_psk = wifi::wpa_passphrase($ssid, $psk)
+  if 64 == $psk.length() {
+    $real_psk = $psk
+  } else {
+    $real_psk = wifi::wpa_passphrase($ssid, $psk)
+  }
 
   case $facts.get('os.family') {
     'debian': {

--- a/spec/defines/infrastructure_spec.rb
+++ b/spec/defines/infrastructure_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'wifi::infrastructure' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:title) { 'Rocketjump5G' }
+
+      let(:facts) { facts }
+
+      let(:params) do
+        {
+          'psk' => psk,
+        }
+      end
+
+      context 'with an ascii psk' do
+        let(:psk) { 'fourwordsalluppercase' }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_file('/etc/NetworkManager/system-connections/Rocketjump5G').with(content: /psk=69a009878c8c09d5afa07e4572bd7eeb3b3d9cb1cae4755cc1dca38ad881f972/) }
+        when 'FreeBSD'
+          it { is_expected.to contain_concat__fragment('/etc/wpa_supplicant.conf-Rocketjump5G').with(content: /psk=69a009878c8c09d5afa07e4572bd7eeb3b3d9cb1cae4755cc1dca38ad881f972/) }
+        end
+      end
+
+      context 'with a hashed psk' do
+        let(:psk) { '69a009878c8c09d5afa07e4572bd7eeb3b3d9cb1cae4755cc1dca38ad881f972' }
+
+        case facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_file('/etc/NetworkManager/system-connections/Rocketjump5G').with(content: /psk=69a009878c8c09d5afa07e4572bd7eeb3b3d9cb1cae4755cc1dca38ad881f972/) }
+        when 'FreeBSD'
+          it { is_expected.to contain_concat__fragment('/etc/wpa_supplicant.conf-Rocketjump5G').with(content: /psk=69a009878c8c09d5afa07e4572bd7eeb3b3d9cb1cae4755cc1dca38ad881f972/) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Accept a 64 chars PSK.  In this case, it is expected to be a pre-hashed
PSK and is used verbatim in the configuration file.